### PR TITLE
Fix pip10 and pypi

### DIFF
--- a/pythonbrewer/brew.py
+++ b/pythonbrewer/brew.py
@@ -112,11 +112,13 @@ def generate_homebrew_formula(python_package_name, formula_name, description, ho
 
     logger.info("")
     logger.info("Downloading release package:")
-    if release_url is None:
+    if release_url:
+        package_name, url, sha256 = python_package_name, release_url, get_release_file_sha256(release_url)
+    elif len(deps) > 0:
         # fetch the details for our python package (should be the last dependency in the ordered dependency list)
         package_name, url, sha256 = calculate_dep_params(deps[-1], required_suffixes=required_suffixes)
     else:
-        package_name, url, sha256 = python_package_name, release_url, get_release_file_sha256(release_url)
+        raise ValueError("No release url found, please provide one")
 
     logger.info("")
 

--- a/pythonbrewer/deplist.py
+++ b/pythonbrewer/deplist.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 from future.utils import iteritems
 
-import pip
 from pipdeptree import build_dist_index, construct_tree, sorted_tree
 
 from pythonbrewer.errors import *
@@ -54,7 +53,14 @@ def build_dep_list(package_name, local_only=True):
     Returns:
         A Python list containing information about the dependencies for that package.
     """
-    packages = pip.get_installed_distributions(local_only=local_only)
+    ## Dealing with pip 10.* api chagnes
+    ## The solution is from:
+    ## https://github.com/naiquevin/pipdeptree/blob/master/pipdeptree.py
+    try:
+        from pip._internal.utils.misc import get_installed_distributions
+    except ImportError:
+        from pip import get_installed_distributions
+    packages = get_installed_distributions(local_only=local_only)
     dist_index = build_dist_index(packages)
     tree = sorted_tree(construct_tree(dist_index))
     nodes = tree.keys()

--- a/pythonbrewer/pypi.py
+++ b/pythonbrewer/pypi.py
@@ -60,7 +60,7 @@ def fetch_pypi_package_files(package_name, package_version, required_suffixes=No
     urls = []
     for link in links:
         filename = re.sub(r"\.[0]+(\d+)", r".\1", link.text.strip().lower())
-        url = "https://pypi.python.org/%s" % link.attrib["href"].replace("../../", "")
+        url = link.attrib["href"]
 
         if filename.startswith(expected_prefix) or filename.startswith(expected_prefix_underscore):
             if required_suffixes is not None:
@@ -92,14 +92,16 @@ def get_pypi_sha256(url):
         raise PackageFetchError(url)
 
     if hash_index_md5 > -1:
+        hash_index_sha256 += len("#md5=")
         md5 = hashlib.md5(response.content).hexdigest().lower()
         if md5 != url[hash_index_md5]:
             raise HashValidationFailedError(url, url[hash_index_md5], md5)
 
     if hash_index_sha256 > -1:
+        hash_index_sha256 += len("#sha256=")
         sha256 = hashlib.sha256(response.content).hexdigest().lower()
-        if sha256 != url[hash_index_sha256]:
-            raise HashValidationFailedError(url, url[hash_index_sha256], sha256)
-        return url[hash_index_sha256]
+        if sha256 != url[hash_index_sha256:]:
+            raise HashValidationFailedError(url, url[hash_index_sha256:], sha256)
+        return url[hash_index_sha256:]
 
     return hashlib.sha256(response.content).hexdigest()

--- a/pythonbrewer/pypi.py
+++ b/pythonbrewer/pypi.py
@@ -82,17 +82,24 @@ def fetch_pypi_package_files(package_name, package_version, required_suffixes=No
 
 
 def get_pypi_sha256(url):
-    """Downloads the given file from the specified URL, optionally validating the MD5 hash (if one is supplied in
-    the URL itself). Returns the SHA-256 hash of the given file."""
-    url_parts = url.split("#md5=")
+    """Downloads the given file from the specified URL, optionally validating the MD5/SHA256 hash (if one is supplied
+    in the URL itself). Returns the SHA-256 hash of the given file."""
+    hash_index_md5 = url.find("#md5=")
+    hash_index_sha256 = url.find("#sha256=")
 
-    response = requests.get(url_parts[0])
+    response = requests.get(url)
     if response.status_code >= 300:
         raise PackageFetchError(url)
 
-    if len(url_parts) > 1:
+    if hash_index_md5 > -1:
         md5 = hashlib.md5(response.content).hexdigest().lower()
-        if md5 != url_parts[1]:
-            raise HashValidationFailedError(url, url_parts[1], md5)
+        if md5 != url[hash_index_md5]:
+            raise HashValidationFailedError(url, url[hash_index_md5], md5)
+
+    if hash_index_sha256 > -1:
+        sha256 = hashlib.sha256(response.content).hexdigest().lower()
+        if sha256 != url[hash_index_sha256]:
+            raise HashValidationFailedError(url, url[hash_index_sha256], sha256)
+        return url[hash_index_sha256]
 
     return hashlib.sha256(response.content).hexdigest()


### PR DESCRIPTION
### fixes that make pybrewer usable again due to:
pip10 internalized `get_installed_distributions`
pypi uses now full-path urls

### also some new features:
except packages with zero dependencies
uses pypi sha256 sums in urls